### PR TITLE
Rename 413 to match RFC 7231

### DIFF
--- a/src/httpcode/__init__.py
+++ b/src/httpcode/__init__.py
@@ -89,7 +89,7 @@ STATUS_CODES = {
           'URI no longer exists and has been permanently removed.'),
     411: ('Length Required', 'Client must specify Content-Length.'),
     412: ('Precondition Failed', 'Precondition in headers is false.'),
-    413: ('Request Entity Too Large', 'Entity is too large.'),
+    413: ('Payload Too Large', 'Payload is too large.'),
     414: ('Request-URI Too Long', 'URI is too long.'),
     415: ('Unsupported Media Type', 'Entity body in unsupported format.'),
     416: ('Requested Range Not Satisfiable',


### PR DESCRIPTION
"Entity Too Large" is from [RFC 2616](https://tools.ietf.org/html/rfc2616#section-10.4.14) but that has been replaced with "Payload Too Large" in [RFC 7231](https://tools.ietf.org/html/rfc7231#section-6.5.11).