### PR TITLE
README: Add quoting around brackets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Filter codes with a regex
 
 ::
 
-    $ hc 30[12]
+    $ hc '30[12]'
     Status code 301
     Message: Moved Permanently
     Code explanation: Object moved permanently -- see URI list


### PR DESCRIPTION
Brackets are shell wildcard special characters and if there are no files `301` or `302` in the current directory, the command `hc 30[12]` will fail if e.g. bash's shell option `failglob` is set:

```
$  hc 30[12]
bash: no match: 30[12]
```

Even worse: Independent of that shell option this command will yield different outcomes depending which files or directories exist in the current directory:

```
$ hc 30[12]
Status code 301
Message: Moved Permanently
Code explanation: Object moved permanently -- see URI list

Status code 302
Message: Found
Code explanation: Object moved temporarily -- see URI list

$ touch 302
$ hc 30[12]
Status code 302
Message: Found
Code explanation: Object moved temporarily -- see URI list

$
```

The proper fix is to quote the argument containing the brackets.